### PR TITLE
Switch to `svelte-codemirror-editor`

### DIFF
--- a/apps/petal-notes/package.json
+++ b/apps/petal-notes/package.json
@@ -33,7 +33,8 @@
     "@lezer/highlight": "catalog:",
     "@lezer/markdown": "catalog:",
     "codemirror": "catalog:",
-    "hypermd": "catalog:"
+    "hypermd": "catalog:",
+    "svelte-codemirror-editor": "catalog:"
   },
   "devDependencies": {
     "@chromatic-com/storybook": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -171,6 +171,9 @@ catalogs:
     svelte-check:
       specifier: ^4.1.4
       version: 4.1.4
+    svelte-codemirror-editor:
+      specifier: ^1.4.1
+      version: 1.4.1
     svelte2tsx:
       specifier: ^0.7.34
       version: 0.7.34
@@ -392,6 +395,9 @@ importers:
       hypermd:
         specifier: 'catalog:'
         version: https://pkg.pr.new/jsimonrichard/HyperMD/hypermd@9c02ff2(@codemirror/commands@6.8.0)(@codemirror/lang-markdown@6.3.2)(@codemirror/language-data@6.5.1)(@codemirror/language@6.10.8)(@codemirror/state@6.5.2)(@codemirror/view@6.36.2)(@lezer/highlight@1.2.1)
+      svelte-codemirror-editor:
+        specifier: 'catalog:'
+        version: 1.4.1(codemirror@6.0.1)(svelte@5.20.1)
     devDependencies:
       '@chromatic-com/storybook':
         specifier: 'catalog:'
@@ -5973,6 +5979,12 @@ packages:
     peerDependencies:
       svelte: ^4.0.0 || ^5.0.0-next.0
       typescript: '>=5.0.0'
+
+  svelte-codemirror-editor@1.4.1:
+    resolution: {integrity: sha512-Pv350iro0Y/AZTT/y2OLaonheQqAwl50Hdfipa2Jv1Z04TSP5kPUyxQnRjqxeRW7DXOX9s5Nd11tHdBl9iYSzw==}
+    peerDependencies:
+      codemirror: ^6.0.0
+      svelte: ^3.0.0 || ^4.0.0 || ^5.0.0
 
   svelte-eslint-parser@1.0.0-next.13:
     resolution: {integrity: sha512-ZcxpplZNwh0ORcn9Lxwj0+3RhcrkSGgM6s1LKijsFCRMNjy2racIPC/OlmYL1R81Xu0/SPMEMvei0e2xfJi6IQ==}
@@ -12812,6 +12824,11 @@ snapshots:
       typescript: 5.7.3
     transitivePeerDependencies:
       - picomatch
+
+  svelte-codemirror-editor@1.4.1(codemirror@6.0.1)(svelte@5.20.1):
+    dependencies:
+      codemirror: 6.0.1
+      svelte: 5.20.1
 
   svelte-eslint-parser@1.0.0-next.13(svelte@5.20.1):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -58,6 +58,7 @@ catalog:
   storybook: ^8.5.6
   svelte: ^5.20.1
   svelte-check: ^4.1.4
+  svelte-codemirror-editor: ^1.4.1
   svelte2tsx: ^0.7.34
   tailwindcss: ^4.0.6
   typed-query-selector: ^2.12.0


### PR DESCRIPTION
This restores the ability to programmatically set the value from Svelte.
You could only set the initial value before, but that's not very Svelte.

Interestingly, I didn't need to disable `optimizeDeps`, perhaps I should send a PR over to scm to update their docs (EDIT: I did file one, https://github.com/touchifyapp/svelte-codemirror-editor/issues/38).