### PR TITLE
Update build Dependabot group

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -23,10 +23,10 @@ updates:
       build:
         patterns:
           - "vite*"
+          - "@vitest/*"
           - "@vite-pwa/*"
           - "workbox*"
           - "browserslist*"
-          - "*html-minifier-terser"
           - "lightningcss"
           - "turbo"
       fontawesome:


### PR DESCRIPTION
Otherwise it doesn't update the vitest dependencies in lockstep.